### PR TITLE
chore: add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @uktrade/webops


### PR DESCRIPTION
The pipeline is still being used by the `s3-sync-pipeline` job (https://jenkins.ci.uktrade.digital/job/s3-sync-pipeline/), so this repository should not be archived.

However, the last time the job ran successfully was in a month ago which failed, the run prior to that was in 2018.